### PR TITLE
Feat - Login and Signup pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@auth/drizzle-adapter": "^0.7.0",
     "@radix-ui/react-avatar": "^1.0.4",
+    "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-slot": "^1.0.2",
     "@t3-oss/env-nextjs": "^0.10.1",
     "class-variance-authority": "^0.7.0",

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,10 @@
+export default async function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  //TODO: implement redirect if user has active session
+  // eg. if (session) redirect("/dashboard");
+
+  return <div className="bg-muted h-screen pt-8">{children}</div>;
+}

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,10 +1,16 @@
-export default async function AuthLayout({
+"use client";
+
+import { useSession } from "next-auth/react";
+import { redirect } from "next/navigation";
+
+export default function AuthLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  //TODO: implement redirect if user has active session
-  // eg. if (session) redirect("/dashboard");
+  const { data: session, status } = useSession();
+
+  if (status === "authenticated") redirect("/dashboard");
 
   return <div className="bg-muted h-screen pt-8">{children}</div>;
 }

--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import Link from "next/link";
+import { useFormState } from "react-dom";
+import { useFormStatus } from "react-dom";
+
+import { Label } from "~/components/ui/label";
+import { Input } from "~/components/ui/input";
+import { Button } from "~/components/ui/button";
+import AuthFormError from "~/components/auth/AuthFormError";
+
+export default function SignInPage() {
+  // const [state, formAction] = useFormState(signInAction, {
+  //   error: "",
+  // });
+
+  return (
+    <main className="bg-popover mx-auto my-4 max-w-lg p-10">
+      <h1 className="text-center text-2xl font-bold">
+        Sign in to your account
+      </h1>
+      {/* <AuthFormError state={state} /> */}
+      <form
+      // action={formAction}
+      >
+        <Label htmlFor="email" className="text-muted-foreground">
+          Email
+        </Label>
+        <Input name="email" id="email" type="email" required />
+        <br />
+        <Label htmlFor="password" className="text-muted-foreground">
+          Password
+        </Label>
+        <Input type="password" name="password" id="password" required />
+        <br />
+        <SubmitButton />
+      </form>
+      <div className="text-muted-foreground mt-4 text-center text-sm">
+        Don&apos;t have an account yet?{" "}
+        <Link
+          href="/sign-up"
+          className="text-accent-foreground hover:text-primary underline"
+        >
+          Create an account
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+const SubmitButton = () => {
+  const { pending } = useFormStatus();
+  return (
+    <Button className="w-full" type="submit" disabled={pending}>
+      Sign{pending ? "ing" : ""} in
+    </Button>
+  );
+};

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Link from "next/link";
+import { useFormState } from "react-dom";
+import { useFormStatus } from "react-dom";
+
+import { Label } from "~/components/ui/label";
+import { Input } from "~/components/ui/input";
+import { Button } from "~/components/ui/button";
+import AuthFormError from "~/components/auth/AuthFormError";
+
+export default function SignUpPage() {
+  // const [state, formAction] = useFormState(signUpAction, {
+  //   error: "",
+  // });
+
+  return (
+    <main className="bg-popover mx-auto my-4 max-w-lg p-10">
+      <h1 className="text-center text-2xl font-bold">Create an account</h1>
+      {/* <AuthFormError state={state} /> */}
+      <form
+      // action={formAction}
+      >
+        <Label htmlFor="email" className="text-muted-foreground">
+          Email
+        </Label>
+        <Input name="email" type="email" id="email" required />
+        <br />
+        <Label htmlFor="password" className="text-muted-foreground">
+          Password
+        </Label>
+        <Input type="password" name="password" id="password" required />
+        <br />
+        <SubmitButton />
+      </form>
+      <div className="text-muted-foreground mt-4 text-center text-sm">
+        Already have an account?{" "}
+        <Link href="/sign-in" className="text-secondary-foreground underline">
+          Sign in
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+const SubmitButton = () => {
+  const { pending } = useFormStatus();
+  return (
+    <Button className="w-full" type="submit" disabled={pending}>
+      Sign{pending ? "ing" : ""} up
+    </Button>
+  );
+};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "~/styles/globals.css";
 
 import { Inter } from "next/font/google";
+import { Providers } from "~/components/auth/providers";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -20,7 +21,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.variable}>{children}</body>
+      <body className={inter.variable}>
+        <Providers>{children}</Providers>
+      </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,13 +11,13 @@ import { Button } from "~/components/ui/button";
 import {
   CheckIcon,
   LockIcon,
-  MenuIcon,
   MergeIcon,
   MountainIcon,
   PieChartIcon,
   ScalingIcon,
   WorkflowIcon,
 } from "~/components/Icons";
+import { webLinks } from "~/config/nav";
 // import Image from "next/image";
 
 export default function HomePage() {
@@ -29,25 +29,16 @@ export default function HomePage() {
           <span className="sr-only">Acme SaaS</span>
         </Link>
         <nav className="ml-auto flex gap-2 sm:gap-6">
-          <Button variant="link" asChild className="hidden sm:block">
-            <Link href="/log-in">Log In</Link>
-          </Button>
-          <Button variant="link" asChild className="hidden sm:block">
-            <Link href="#features">Features</Link>
-          </Button>{" "}
-          <Button variant="link" asChild className="hidden sm:block">
-            <Link href="#testimonials">Testimonials</Link>
-          </Button>
-          <Button variant="link" asChild className="hidden sm:block">
-            <Link href="#pricing">Pricing</Link>
-          </Button>
-          <Button variant="link" asChild className="hidden sm:block">
-            <Link href="#contact">Contact</Link>
-          </Button>
-          <Button className="sm:hidden" size="icon" variant="ghost">
-            <MenuIcon className="h-6 w-6" />
-            <span className="sr-only">Toggle navigation</span>
-          </Button>
+          {webLinks.map((link) => (
+            <Button
+              key={link.title}
+              variant="link"
+              asChild
+              className="hidden sm:block"
+            >
+              <Link href={link.href}>{link.title}</Link>
+            </Button>
+          ))}
         </nav>
       </header>
       <main className="flex-1">

--- a/src/components/auth/AuthFormError.tsx
+++ b/src/components/auth/AuthFormError.tsx
@@ -1,0 +1,10 @@
+export default function AuthFormError({ state }: { state: { error: string } }) {
+  if (state.error)
+    return (
+      <div className="bg-destructive text-destructive-foreground my-4 w-full p-4 text-xs">
+        <h3 className="font-bold">Error</h3>
+        <p>{state.error}</p>
+      </div>
+    );
+  return null;
+}

--- a/src/components/auth/SignOutBtn.tsx
+++ b/src/components/auth/SignOutBtn.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Button } from "../ui/button";
+import { useFormStatus } from "react-dom";
+// import { signOutAction } from "@/lib/actions/users";
+
+export default function SignOutBtn() {
+  return (
+    <form
+      // TODO: Create Sign Out Action
+      // action={signOutAction}
+      className="w-full text-left"
+    >
+      <Btn />
+    </form>
+  );
+}
+
+const Btn = () => {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" disabled={pending} variant={"destructive"}>
+      Sign{pending ? "ing" : ""} out
+    </Button>
+  );
+};

--- a/src/components/auth/providers.tsx
+++ b/src/components/auth/providers.tsx
@@ -1,0 +1,7 @@
+// provider.tsx
+"use client";
+import { SessionProvider } from "next-auth/react";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,25 @@
+import * as React from "react"
+
+import { cn } from "~/lib/utils"
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus-visible:ring-slate-300",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,7 +1,8 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "~/lib/utils"
+import { cn } from "~/lib/utils";
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {}
 
@@ -12,14 +13,14 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         type={type}
         className={cn(
           "flex h-10 w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus-visible:ring-slate-300",
-          className
+          className,
         )}
         ref={ref}
         {...props}
       />
-    )
-  }
-)
-Input.displayName = "Input"
+    );
+  },
+);
+Input.displayName = "Input";
 
-export { Input }
+export { Input };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "~/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -1,0 +1,7 @@
+export const webLinks = [
+  { href: "#features", title: "Features" },
+  { href: "#testimonials", title: "Testimonials" },
+  { href: "#pricing", title: "Pricing" },
+  { href: "#contact", title: "Contact" },
+  { href: "/sign-in", title: "Sign In" },
+];

--- a/yarn.lock
+++ b/yarn.lock
@@ -493,6 +493,14 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@radix-ui/react-label@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-label/-/react-label-2.0.2.tgz#9c72f1d334aac996fdc27b48a8bdddd82108fb6d"
+  integrity sha512-N5ehvlM7qoTLx7nWPodsPYPgMzA5WM8zZChQg8nyFJKnDO5WHdba1vv5/H6IO5LtJMfD2Q3wh1qHFGNtK0w3bQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
+
 "@radix-ui/react-primitive@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz#d49ea0f3f0b2fe3ab1cb5667eb03e8b843b914d0"


### PR DESCRIPTION
## Additions
- Installed new shadcn/ui components - Input, Label
- Created nextAuth provider component and integrated into base layout.tsx (prep for nextAuth integration)
- Created (auth) pages including `SignUpPage` and `SignInPage` components

### Changes
- Abstracted landing page nav links to `/config/nav.ts` folder for easier location